### PR TITLE
Thort/hotkeys

### DIFF
--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,12 +2,12 @@ Uuid: 0d05f52c00a64cb2b2bea68744f6316c
 ExtensionType: 2
 Name: Copy Request Response
 RepoName: copy-request-response
-ScreenVersion: 2.0.0
-SerialVersion: 15
+ScreenVersion: 2.1.0
+SerialVersion: 16
 MinPlatformVersion: 0
 ProOnly: False
 Author: Emanuel Duss / Tobias Hort-Giess / Compass Security
 ShortDescription: Copy methods in the context menu of selected messages and requests/responses.
-EntryPoint: build/libs/burp-copy-request-response-2.0.0.jar
+EntryPoint: build/libs/burp-copy-request-response-2.1.0.jar
 BuildCommand: ./gradlew jar
 SupportedProducts: Pro, Community

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ compileJava   {
 
 dependencies {
     compileOnly 'net.portswigger.burp.extensions:montoya-api:2025.3'
+    implementation 'com.miglayout:miglayout-swing:11.4.2'
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'ch.csnc.burp'
-version '2.0.0'
+version '2.1.0'
 
 repositories {
     mavenCentral()
@@ -15,7 +15,7 @@ compileJava   {
 }
 
 dependencies {
-    compileOnly 'net.portswigger.burp.extensions:montoya-api:2024.7'
+    compileOnly 'net.portswigger.burp.extensions:montoya-api:2025.3'
 }
 
 jar {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/ch/csnc/burp/CopyRequestResponseConfiguration.java
+++ b/src/main/java/ch/csnc/burp/CopyRequestResponseConfiguration.java
@@ -1,0 +1,69 @@
+package ch.csnc.burp;
+
+public class CopyRequestResponseConfiguration {
+
+    private static final String CUT_TEXT_KEY = "CopyRequestResponseCutText";
+    private static final String CUT_TEXT_NBSP_KEY = "CopyRequestResponseCutTextNbsp";
+    private static final String COPY_FULL_FULL_OR_SELECTION_KEY = "CopyRequestResponseCopyFullFullOrSelectionHotKey";
+    private static final String COPY_FULL_HEADER_KEY = "CopyRequestResponseCopyFullHeaderHotKey";
+
+    public static String cutText() {
+        var cutText = CopyRequestResponseExtension.api().persistence().preferences().getString(CUT_TEXT_KEY);
+        if (cutText == null) {
+            cutText = "[...]";
+            setCutText(cutText);
+        }
+        if (useNonBreakableSpace()) {
+            cutText = cutText.replaceAll(" ", "\u00a0");
+        }
+        return cutText;
+    }
+
+    public static void setCutText(String cutText) {
+        CopyRequestResponseExtension.api().persistence().preferences().setString(CUT_TEXT_KEY, cutText);
+    }
+
+    public static boolean useNonBreakableSpace() {
+        var useNbsp = CopyRequestResponseExtension.api().persistence().preferences().getBoolean(CUT_TEXT_NBSP_KEY);
+        if (useNbsp == null) {
+            useNbsp = false;
+        }
+        setUseNonBreakableSpace(useNbsp);
+        return useNbsp;
+    }
+
+    public static void setUseNonBreakableSpace(boolean enabled) {
+        CopyRequestResponseExtension.api().persistence().preferences().setBoolean(CUT_TEXT_NBSP_KEY, enabled);
+    }
+
+    public static String copyFullFullOrSelectionHotKey() {
+        var hotKey = CopyRequestResponseExtension.api().persistence().preferences().getString(COPY_FULL_FULL_OR_SELECTION_KEY);
+        if (hotKey == null) {
+            hotKey = "Ctrl+Shift+C";
+            setCopyFullFullOrSelectionHotKey(hotKey);
+        }
+        return hotKey;
+    }
+
+    public static void setCopyFullFullOrSelectionHotKey(String hotKey) {
+        CopyRequestResponseExtension.api().persistence().preferences().setString(COPY_FULL_FULL_OR_SELECTION_KEY, hotKey);
+    }
+
+    public static String copyFullHeaderHotKey() {
+        var hotKey = CopyRequestResponseExtension.api().persistence().preferences().getString(COPY_FULL_HEADER_KEY);
+        if (hotKey == null) {
+            hotKey = "Ctrl+Alt+C";
+            setCopyFullHeaderHotKey(hotKey);
+        }
+        return hotKey;
+    }
+
+    public static void setCopyFullHeaderHotKey(String hotKey) {
+        CopyRequestResponseExtension.api().persistence().preferences().setString(COPY_FULL_HEADER_KEY, hotKey);
+    }
+
+    private CopyRequestResponseConfiguration() {
+        // static class
+    }
+
+}

--- a/src/main/java/ch/csnc/burp/CopyRequestResponseConfigurationDialog.java
+++ b/src/main/java/ch/csnc/burp/CopyRequestResponseConfigurationDialog.java
@@ -1,0 +1,75 @@
+package ch.csnc.burp;
+
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import javax.swing.*;
+import net.miginfocom.swing.MigLayout;
+
+public class CopyRequestResponseConfigurationDialog {
+
+    private final JDialog dialog;
+
+    public CopyRequestResponseConfigurationDialog() {
+        var cutTextLabel = new JLabel("Cut Text:");
+        var copyFullFullOrSelectionHotKeyLabel = new JLabel("HotKey for Copy Full/Full or Full/Header + Selected Data:");
+        var copyFullHeaderLabel = new JLabel("HotKey for Copy Full/Header:");
+
+        var cutTextTextField = new JTextField(CopyRequestResponseConfiguration.cutText());
+        var copyFullFullOrSelectionHotKeyTextField = new JTextField(CopyRequestResponseConfiguration.copyFullFullOrSelectionHotKey());
+        var copyFullHeaderTextField = new JTextField(CopyRequestResponseConfiguration.copyFullHeaderHotKey());
+
+        cutTextTextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyReleased(KeyEvent e) {
+                e.consume();
+                CopyRequestResponseConfiguration.setCutText(cutTextTextField.getText());
+            }
+        });
+
+        copyFullFullOrSelectionHotKeyTextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyReleased(KeyEvent e) {
+                e.consume();
+                CopyRequestResponseConfiguration.setCopyFullFullOrSelectionHotKey(copyFullFullOrSelectionHotKeyTextField.getText());
+            }
+        });
+
+        copyFullHeaderTextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyReleased(KeyEvent e) {
+                e.consume();
+                CopyRequestResponseConfiguration.setCopyFullHeaderHotKey(copyFullHeaderTextField.getText());
+            }
+        });
+
+        var textFieldColumns = 40;
+        cutTextTextField.setColumns(textFieldColumns);
+        copyFullFullOrSelectionHotKeyTextField.setColumns(textFieldColumns);
+        copyFullHeaderTextField.setColumns(textFieldColumns);
+
+        var useNbspCheckbox = new JCheckBox("Use Non-Breakable Spaces");
+        useNbspCheckbox.setSelected(CopyRequestResponseConfiguration.useNonBreakableSpace());
+        useNbspCheckbox.addActionListener(event -> CopyRequestResponseConfiguration.setUseNonBreakableSpace(useNbspCheckbox.isSelected()));
+
+        var panel = new JPanel();
+        panel.setLayout(new MigLayout());
+        panel.add(cutTextLabel);
+        panel.add(cutTextTextField, "grow, wrap");
+        panel.add(useNbspCheckbox, "skip, grow, wrap");
+        panel.add(copyFullFullOrSelectionHotKeyLabel);
+        panel.add(copyFullFullOrSelectionHotKeyTextField, "grow, wrap");
+        panel.add(copyFullHeaderLabel);
+        panel.add(copyFullHeaderTextField, "grow, wrap");
+
+        this.dialog = new JDialog(CopyRequestResponseExtension.api().userInterface().swingUtils().suiteFrame(), true);
+        this.dialog.setLocationRelativeTo(CopyRequestResponseExtension.api().userInterface().swingUtils().suiteFrame());
+        this.dialog.setTitle("CopyRequestResponse Configuration Dialog");
+        this.dialog.setContentPane(panel);
+        this.dialog.setResizable(false);
+        this.dialog.setSize(610, 170);
+    }
+
+    public void show() {
+        this.dialog.setVisible(true);
+    }
+}

--- a/src/main/java/ch/csnc/burp/CopyRequestResponseContextMenuItemsProvider.java
+++ b/src/main/java/ch/csnc/burp/CopyRequestResponseContextMenuItemsProvider.java
@@ -1,45 +1,14 @@
 package ch.csnc.burp;
 
-import burp.api.montoya.MontoyaApi;
-import burp.api.montoya.http.message.responses.HttpResponse;
 import burp.api.montoya.ui.contextmenu.ContextMenuEvent;
 import burp.api.montoya.ui.contextmenu.ContextMenuItemsProvider;
 import burp.api.montoya.ui.contextmenu.MessageEditorHttpRequestResponse;
-
-import javax.swing.*;
-import java.awt.*;
-import java.awt.datatransfer.StringSelection;
+import java.awt.Component;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.function.Supplier;
+import javax.swing.JMenuItem;
 
 public class CopyRequestResponseContextMenuItemsProvider implements ContextMenuItemsProvider {
-
-    private static final String CUT_TEXT;
-
-    static {
-        var cutText =
-                Optional.ofNullable(System.getProperty("copyRequestResponse.cutText.text"))
-                        .orElse("[...]");
-
-        var useNbsp =
-                Boolean.valueOf(
-                        Optional.ofNullable(System.getProperty("copyRequestResponse.cutText.useNbsp"))
-                                .orElse("false"));
-
-        if (useNbsp) {
-            cutText = cutText.replaceAll(" ", "\u00a0");
-        }
-
-        CUT_TEXT = cutText;
-    }
-
-    private final MontoyaApi api;
-
-    public CopyRequestResponseContextMenuItemsProvider(MontoyaApi api) {
-        this.api = api;
-    }
 
     @Override
     public List<Component> provideMenuItems(ContextMenuEvent event) {
@@ -53,133 +22,24 @@ public class CopyRequestResponseContextMenuItemsProvider implements ContextMenuI
         var menuItems = new ArrayList<Component>();
 
         var copyFullFull = new JMenuItem("Copy HTTP Request & Response (Full/Full)");
-        copyFullFull.addActionListener(actionEvent -> this.copyFullFull(editor));
+        copyFullFull.addActionListener(actionEvent -> CopyRequestResponseCopyActions.copyFullFull(editor));
         menuItems.add(copyFullFull);
 
         var copyFullHeader = new JMenuItem("Copy HTTP Request & Response (Full/Header)");
-        copyFullHeader.addActionListener(actionEvent -> this.copyFullHeader(editor));
+        copyFullHeader.addActionListener(actionEvent -> CopyRequestResponseCopyActions.copyFullHeader(editor));
         menuItems.add(copyFullHeader);
 
         if (editor.selectionContext() == MessageEditorHttpRequestResponse.SelectionContext.RESPONSE) {
             var copyFullHeaderPlusSelectedData = new JMenuItem("Copy HTTP Request & Response (Full/Header + Selected Data)");
-            copyFullHeaderPlusSelectedData.addActionListener(actionEvent -> this.copyFullHeaderPlusSelectedData(editor));
+            copyFullHeaderPlusSelectedData.addActionListener(actionEvent -> CopyRequestResponseCopyActions.copyFullHeaderPlusSelectedData(editor));
             menuItems.add(copyFullHeaderPlusSelectedData);
         }
+
+        var openConfiguration = new JMenuItem("Open Configuration");
+        openConfiguration.addActionListener(actionEvent -> new CopyRequestResponseConfigurationDialog().show());
+        menuItems.add(openConfiguration);
 
         return List.copyOf(menuItems);
     }
 
-    private void copyFullFull(MessageEditorHttpRequestResponse editor) {
-        var requestResponse = editor.requestResponse();
-
-        var text = "%s\n\n%s".formatted(
-                requestResponse.request().toString().strip(),
-                Optional.ofNullable(requestResponse.response())
-                        .map(HttpResponse::toString)
-                        .map(String::strip)
-                        .orElse(""));
-
-        this.toClipboard(text);
-    }
-
-    private void copyFullHeader(MessageEditorHttpRequestResponse editor) {
-        var requestResponse = editor.requestResponse();
-        var requestString = requestResponse.request().toString().strip();
-
-        var responseString = "";
-        if (requestResponse.hasResponse()) {
-            var response = requestResponse.response();
-            responseString = response.toString().substring(0, response.bodyOffset()).strip();
-            responseString += "\n\n";
-            responseString += CUT_TEXT;
-        }
-
-        var text = "%s\n\n%s".formatted(requestString, responseString);
-        this.toClipboard(text);
-    }
-
-    private void copyFullHeaderPlusSelectedData(MessageEditorHttpRequestResponse editor) {
-        var requestResponse = editor.requestResponse();
-        var requestString = requestResponse.request().toString().strip();
-
-        Supplier<String> responseStringSupplier = () -> {
-            if (!requestResponse.hasResponse()) {
-                return "";
-            }
-
-            var response = requestResponse.response();
-            var responseString = response.toString().substring(0, response.bodyOffset()).strip();
-            responseString += "\n\n";
-
-
-            var selectionOffsets = editor.selectionOffsets().orElse(null);
-
-            if (selectionOffsets == null) {
-                // nothing selected
-                responseString += CUT_TEXT;
-                return responseString;
-            }
-
-            var startIndex = selectionOffsets.startIndexInclusive();
-            if (startIndex < response.bodyOffset()) {
-                startIndex = response.bodyOffset();
-            }
-
-            var endIndex = selectionOffsets.endIndexExclusive();
-            this.api.logging().logToError("start: %d, end %d".formatted(startIndex, endIndex));
-            if (endIndex <= startIndex) {
-                responseString += CUT_TEXT;
-                return responseString;
-            }
-
-            var selectedText = response.toByteArray().subArray(startIndex, endIndex);
-
-            if (startIndex == response.bodyOffset() && endIndex < response.toByteArray().length()) {
-                responseString += selectedText;
-                responseString += CUT_TEXT;
-                return responseString;
-            }
-
-            if (startIndex > response.bodyOffset() && endIndex == response.toByteArray().length()) {
-                responseString += CUT_TEXT;
-                responseString += selectedText;
-                return responseString;
-            }
-
-            if (startIndex == response.bodyOffset() && endIndex == response.toByteArray().length()) {
-                responseString += selectedText;
-                return responseString;
-            }
-
-            responseString += CUT_TEXT;
-            responseString += selectedText;
-            responseString += CUT_TEXT;
-            return responseString;
-        };
-
-        var text = "%s\n\n%s".formatted(requestString, responseStringSupplier.get());
-
-        // Ugly hack because VMware is messing up the clipboard if a text is still selected, the function
-        // has to be run in a separate thread which sleeps for 0.2 seconds.
-        var thread = new Thread(() -> {
-            try {
-                Thread.sleep(200);
-                this.toClipboard(text);
-            } catch (InterruptedException exc) {
-                Thread.currentThread().interrupt();
-            }
-        });
-        thread.setName("ToClipboardThread");
-        thread.setDaemon(true);
-        thread.start();
-    }
-
-    private void toClipboard(String text0) {
-        var text1 = text0.replaceAll("\r\n", "\n");
-        var systemClipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-        var systemSelection = Toolkit.getDefaultToolkit().getSystemSelection();
-        var transferText = new StringSelection(text1);
-        systemClipboard.setContents(transferText, null);
-        systemSelection.setContents(transferText, null);
-    }
 }

--- a/src/main/java/ch/csnc/burp/CopyRequestResponseCopyActions.java
+++ b/src/main/java/ch/csnc/burp/CopyRequestResponseCopyActions.java
@@ -1,0 +1,132 @@
+package ch.csnc.burp;
+
+import burp.api.montoya.http.message.responses.HttpResponse;
+import burp.api.montoya.ui.contextmenu.MessageEditorHttpRequestResponse;
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class CopyRequestResponseCopyActions {
+
+
+
+    public static void copyFullFull(MessageEditorHttpRequestResponse editor) {
+        var requestResponse = editor.requestResponse();
+
+        var text = "%s\n\n%s".formatted(
+                requestResponse.request().toString().strip(),
+                Optional.ofNullable(requestResponse.response())
+                        .map(HttpResponse::toString)
+                        .map(String::strip)
+                        .orElse(""));
+
+        toClipboard(text);
+    }
+
+    public static void copyFullHeader(MessageEditorHttpRequestResponse editor) {
+        var requestResponse = editor.requestResponse();
+        var requestString = requestResponse.request().toString().strip();
+
+        var responseString = "";
+        if (requestResponse.hasResponse()) {
+            var response = requestResponse.response();
+            responseString = response.toString().substring(0, response.bodyOffset()).strip();
+            responseString += "\n\n";
+            responseString += CopyRequestResponseConfiguration.cutText();
+        }
+
+        var text = "%s\n\n%s".formatted(requestString, responseString);
+        toClipboard(text);
+    }
+
+    public static void copyFullHeaderPlusSelectedData(MessageEditorHttpRequestResponse editor) {
+        var requestResponse = editor.requestResponse();
+        var requestString = requestResponse.request().toString().strip();
+
+        Supplier<String> responseStringSupplier = () -> {
+            if (!requestResponse.hasResponse()) {
+                return "";
+            }
+
+            var response = requestResponse.response();
+            var responseString = response.toString().substring(0, response.bodyOffset()).strip();
+            responseString += "\n\n";
+
+
+            var selectionOffsets = editor.selectionOffsets().orElse(null);
+
+            if (selectionOffsets == null) {
+                // nothing selected
+                responseString += CopyRequestResponseConfiguration.cutText();
+                return responseString;
+            }
+
+            var startIndex = selectionOffsets.startIndexInclusive();
+            if (startIndex < response.bodyOffset()) {
+                startIndex = response.bodyOffset();
+            }
+
+            var endIndex = selectionOffsets.endIndexExclusive();
+            CopyRequestResponseExtension.api().logging().logToError("start: %d, end %d".formatted(startIndex, endIndex));
+            if (endIndex <= startIndex) {
+                responseString += CopyRequestResponseConfiguration.cutText();
+                return responseString;
+            }
+
+            var selectedText = response.toByteArray().subArray(startIndex, endIndex);
+
+            if (startIndex == response.bodyOffset() && endIndex < response.toByteArray().length()) {
+                responseString += selectedText;
+                responseString += CopyRequestResponseConfiguration.cutText();
+                return responseString;
+            }
+
+            if (startIndex > response.bodyOffset() && endIndex == response.toByteArray().length()) {
+                responseString += CopyRequestResponseConfiguration.cutText();
+                responseString += selectedText;
+                return responseString;
+            }
+
+            if (startIndex == response.bodyOffset() && endIndex == response.toByteArray().length()) {
+                responseString += selectedText;
+                return responseString;
+            }
+
+            responseString += CopyRequestResponseConfiguration.cutText();
+            responseString += selectedText;
+            responseString += CopyRequestResponseConfiguration.cutText();
+            return responseString;
+        };
+
+        var text = "%s\n\n%s".formatted(requestString, responseStringSupplier.get());
+
+        // Ugly hack because VMware is messing up the clipboard if a text is still selected, the function
+        // has to be run in a separate thread which sleeps for 0.2 seconds.
+        var thread = new Thread(() -> {
+            try {
+                Thread.sleep(200);
+                toClipboard(text);
+            } catch (InterruptedException exc) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        thread.setName("ToClipboardThread");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    private static void toClipboard(String text0) {
+        var text1 = text0.replaceAll("\r\n", "\n");
+        var systemClipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+        var systemSelection = Toolkit.getDefaultToolkit().getSystemSelection();
+        var transferText = new StringSelection(text1);
+        systemClipboard.setContents(transferText, null);
+        systemSelection.setContents(transferText, null);
+    }
+
+    private CopyRequestResponseCopyActions() {
+        // static class
+    }
+
+}

--- a/src/main/java/ch/csnc/burp/CopyRequestResponseCopyActions.java
+++ b/src/main/java/ch/csnc/burp/CopyRequestResponseCopyActions.java
@@ -9,8 +9,6 @@ import java.util.function.Supplier;
 
 public class CopyRequestResponseCopyActions {
 
-
-
     public static void copyFullFull(MessageEditorHttpRequestResponse editor) {
         var requestResponse = editor.requestResponse();
 

--- a/src/main/java/ch/csnc/burp/CopyRequestResponseExtension.java
+++ b/src/main/java/ch/csnc/burp/CopyRequestResponseExtension.java
@@ -2,17 +2,26 @@ package ch.csnc.burp;
 
 import burp.api.montoya.BurpExtension;
 import burp.api.montoya.MontoyaApi;
-
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 
 import static java.util.Objects.requireNonNull;
 
 public class CopyRequestResponseExtension implements BurpExtension {
+
+    private static MontoyaApi api;
+
+    public static MontoyaApi api() {
+        return api;
+    }
+
     @Override
     public void initialize(MontoyaApi api) {
+        CopyRequestResponseExtension.api = api;
         api.extension().setName("Copy Request Response");
-        api.userInterface().registerContextMenuItemsProvider(new CopyRequestResponseContextMenuItemsProvider(api));
+        api.userInterface().registerContextMenuItemsProvider(new CopyRequestResponseContextMenuItemsProvider());
+
+        CopyRequestResponseHotKeyHandler.register();
 
         api.logging().logToOutput("Copy Request Response loaded");
 

--- a/src/main/java/ch/csnc/burp/CopyRequestResponseHotKeyHandler.java
+++ b/src/main/java/ch/csnc/burp/CopyRequestResponseHotKeyHandler.java
@@ -1,0 +1,27 @@
+package ch.csnc.burp;
+
+import burp.api.montoya.ui.contextmenu.MessageEditorHttpRequestResponse;
+import burp.api.montoya.ui.hotkey.HotKeyContext;
+
+public class CopyRequestResponseHotKeyHandler {
+
+    public static void register() {
+        CopyRequestResponseExtension.api().userInterface().registerHotKeyHandler(HotKeyContext.HTTP_MESSAGE_EDITOR, CopyRequestResponseConfiguration.copyFullFullOrSelectionHotKey(), event -> {
+            event.messageEditorRequestResponse().ifPresent(messageEditorHttpRequestResponse -> {
+                if (messageEditorHttpRequestResponse.selectionContext() == MessageEditorHttpRequestResponse.SelectionContext.RESPONSE && messageEditorHttpRequestResponse.selectionOffsets().isPresent()) {
+                    CopyRequestResponseCopyActions.copyFullHeaderPlusSelectedData(messageEditorHttpRequestResponse);
+                } else {
+                    CopyRequestResponseCopyActions.copyFullFull(messageEditorHttpRequestResponse);
+                }
+            });
+        });
+
+        CopyRequestResponseExtension.api().userInterface().registerHotKeyHandler(HotKeyContext.HTTP_MESSAGE_EDITOR, CopyRequestResponseConfiguration.copyFullHeaderHotKey(), event -> {
+            event.messageEditorRequestResponse().ifPresent(CopyRequestResponseCopyActions::copyFullHeader);
+        });
+    }
+
+    private CopyRequestResponseHotKeyHandler() {
+        // static class
+    }
+}


### PR DESCRIPTION
Added hotkey support.

You may need to test with "Early Adopter" Version of Burp Suite.

Ctrl-Shift-C copies Request Full/Response Full, if nothing is selected in the response. If you have selected something in the response body, it will copy Request Full/Response Headers + Selected Data.

Ctrl-Alt-C will copy Request Full/Response Headers.

Not happy with the hot keys? No problem, configure it yourself. There is a new context menu item, that allow you configure that stuff:

![image](https://github.com/user-attachments/assets/587a4fe5-9067-45ce-8b39-faae12256997)

![image](https://github.com/user-attachments/assets/b4662655-d509-4586-85b0-83c7a8a29442)


