### PR TITLE
JSON pretty-printing of request and response body

### DIFF
--- a/src/main/java/ch/csnc/burp/CopyRequestResponseConfiguration.java
+++ b/src/main/java/ch/csnc/burp/CopyRequestResponseConfiguration.java
@@ -6,6 +6,7 @@ public class CopyRequestResponseConfiguration {
     private static final String CUT_TEXT_NBSP_KEY = "CopyRequestResponseCutTextNbsp";
     private static final String COPY_FULL_FULL_OR_SELECTION_KEY = "CopyRequestResponseCopyFullFullOrSelectionHotKey";
     private static final String COPY_FULL_HEADER_KEY = "CopyRequestResponseCopyFullHeaderHotKey";
+    private static final String ENABLE_JSON_FORMATTING_KEY = "CopyRequestResponseEnableJSONFormatting";
 
     public static String cutText() {
         var cutText = CopyRequestResponseExtension.api().persistence().preferences().getString(CUT_TEXT_KEY);
@@ -62,6 +63,19 @@ public class CopyRequestResponseConfiguration {
         CopyRequestResponseExtension.api().persistence().preferences().setString(COPY_FULL_HEADER_KEY, hotKey);
     }
 
+    public static boolean enableJsonFormatting() {
+        var enableJson = CopyRequestResponseExtension.api().persistence().preferences().getBoolean(ENABLE_JSON_FORMATTING_KEY);
+        if (enableJson == null) {
+            enableJson = false;
+        }
+        setEnableJsonFormatting(enableJson);
+        return enableJson;
+    }
+
+    public static void setEnableJsonFormatting(boolean enabled) {
+        CopyRequestResponseExtension.api().persistence().preferences().setBoolean(ENABLE_JSON_FORMATTING_KEY, enabled);
+    }
+    
     private CopyRequestResponseConfiguration() {
         // static class
     }

--- a/src/main/java/ch/csnc/burp/CopyRequestResponseConfigurationDialog.java
+++ b/src/main/java/ch/csnc/burp/CopyRequestResponseConfigurationDialog.java
@@ -51,6 +51,10 @@ public class CopyRequestResponseConfigurationDialog {
         useNbspCheckbox.setSelected(CopyRequestResponseConfiguration.useNonBreakableSpace());
         useNbspCheckbox.addActionListener(event -> CopyRequestResponseConfiguration.setUseNonBreakableSpace(useNbspCheckbox.isSelected()));
 
+        var enableJsonFormattingCheckbox = new JCheckBox("Enable pretty-printing of JSON data");
+        enableJsonFormattingCheckbox.setSelected(CopyRequestResponseConfiguration.enableJsonFormatting());
+        enableJsonFormattingCheckbox.addActionListener(event -> CopyRequestResponseConfiguration.setEnableJsonFormatting(enableJsonFormattingCheckbox.isSelected()));
+
         var panel = new JPanel();
         panel.setLayout(new MigLayout());
         panel.add(cutTextLabel);
@@ -60,6 +64,7 @@ public class CopyRequestResponseConfigurationDialog {
         panel.add(copyFullFullOrSelectionHotKeyTextField, "grow, wrap");
         panel.add(copyFullHeaderLabel);
         panel.add(copyFullHeaderTextField, "grow, wrap");
+        panel.add(enableJsonFormattingCheckbox, "grow, wrap");
 
         this.dialog = new JDialog(CopyRequestResponseExtension.api().userInterface().swingUtils().suiteFrame(), true);
         this.dialog.setLocationRelativeTo(CopyRequestResponseExtension.api().userInterface().swingUtils().suiteFrame());


### PR DESCRIPTION
# Overview
Burp automatically formats JSON data in request or response bodies. However, this is lost when copying the output.
This adds a new feature to the extension that uses a built-in method to parse JSON data and formats it before the text is copied to the clipboard.

![image](https://github.com/user-attachments/assets/2b572b9f-ac21-443e-82ae-dc3ed34fee93)


# Example
Without formatting:

```
GET /comments/1 HTTP/1.1
Host: dummyjson.com
Accept-Language: en-US,en;q=0.9
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
Accept-Encoding: gzip, deflate, br
Priority: u=0, i
Connection: keep-alive
Content-Length: 13

{"foo":"bar"}

HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Length: 133
Content-Type: application/json; charset=utf-8
Date: Tue, 08 Jul 2025 14:05:01 GMT
Etag: W/"85-FEb3h4CPX0SmhhGt/sXFy+BW+u4"
Server: railway-edge
Strict-Transport-Security: max-age=15552000; includeSubDomains
Vary: Accept-Encoding
[...]

{"id":1,"body":"This is some awesome thinking!","postId":242,"likes":3,"user":{"id":105,"username":"emmac","fullName":"Emma Wilson"}}
```

With formatting enabled:

```
GET /comments/1 HTTP/1.1
Host: dummyjson.com
Accept-Language: en-US,en;q=0.9
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
Accept-Encoding: gzip, deflate, br
Priority: u=0, i
Connection: keep-alive
Content-Length: 13

{
  "foo": "bar"
}

HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Length: 133
Content-Type: application/json; charset=utf-8
Date: Tue, 08 Jul 2025 14:05:01 GMT
Etag: W/"85-FEb3h4CPX0SmhhGt/sXFy+BW+u4"
Server: railway-edge
Strict-Transport-Security: max-age=15552000; includeSubDomains
Vary: Accept-Encoding
[...]

{
  "id": 1,
  "body": "This is some awesome thinking!",
  "postId": 242,
  "likes": 3,
  "user": {
    "id": 105,
    "username": "emmac",
    "fullName": "Emma Wilson"
  }
}
```